### PR TITLE
Add pillow to dependencies

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -15,6 +15,7 @@ setup(
         "h5py",
         "pandas",
         "scipy",
+        "pillow",
         "numpy",
         "requests",
         "flask",


### PR DESCRIPTION
`loom tile ...` gives `AttributeError: module 'scipy.misc' has no attribute 'toimage'` on a fresh install. The [FAQ](https://github.com/linnarsson-lab/loom-viewer/blob/master/docs/FAQ.md#generating-tiles-fails-with-error---module-scipymisc-has-no-attribute-toimage) mentions how to solve this by running `pip install pillow`, and there’s [a comment](https://github.com/linnarsson-lab/loom-viewer/issues/137#issuecomment-345683156) in an issue which can be found when searching for the error, but adding `pillow` to the dependencies would fix this for good.