### PR TITLE
Updated npm packages and deprecated webpack plugins/configuration.

### DIFF
--- a/build_client
+++ b/build_client
@@ -32,7 +32,7 @@ if  [ "${1:-dev}" == "dev" ]; then
   echo "=== Run WebPack with development build"
   echo ""
 
-  webpack --config='webpack.config.dev.js' --progress --profile --colors
+  webpack --config='webpack.config.dev.js' --progress --profile --colors --mode=development
 
   # I haven't figured out how to both generate correct paths in the webpack HTML
   # template, and have the resulting index.html be put in the right folders.
@@ -48,7 +48,7 @@ elif [ "${1:-dev}" == "prod" ]; then
   echo "=== Run WebPack with production build"
   echo ""
 
-  webpack --config='webpack.config.prod.js' --progress --profile --colors
+  webpack --config='webpack.config.prod.js' --progress --profile --colors --mode=production
 
   mv ./python/loom_viewer/index.html ./python/loom_viewer/static/index.html
   cp ./client/images/favicon.ico ./python/loom_viewer/static/favicon.ico

--- a/build_client.bat
+++ b/build_client.bat
@@ -22,7 +22,7 @@ IF /i "%1"=="prod" (
     echo === Run WebPack with production build
     echo.
 
-    webpack --config=webpack.config.prod.js --progress --profile --colors
+    webpack --config=webpack.config.prod.js --progress --profile --colors --mode=production
 
     :: I haven't figured out how to both generate correct paths in the webpack HTML
     :: template, and have the resulting index.html be put in the right folders.
@@ -43,7 +43,7 @@ IF /i "%1"=="prod" (
     echo === Run WebPack with development build
     echo.
 
-    webpack --config=webpack.config.dev.js --progress --profile --colors
+    webpack --config=webpack.config.dev.js --progress --profile --colors --mode=development
 
     echo.
     echo copy .\client\images\favicon.ico .\python\loom_viewer\static\ /Y

--- a/package.json
+++ b/package.json
@@ -76,19 +76,20 @@
     "babel-preset-minify": "^0.3.0",
     "babel-preset-react": "^6.24.1",
     "babelify": "^8.0.0",
-    "css-loader": "^0.28.11",
+    "css-loader": "^3.1.0",
     "csso-webpack-plugin": "^1.0.0-beta.12",
     "eslint-import-resolver-babel-module": "^4.0.0",
     "eslint-plugin-import": "^2.10.0",
-    "extract-text-webpack-plugin": "^3.0.2",
     "file-loader": "^1.1.11",
     "html-webpack-plugin": "^3.2.0",
+    "mini-css-extract-plugin": "^0.8.0",
     "prop-types": "^15.6.1",
     "style-loader": "^0.20.3",
     "sw-precache-webpack-plugin": "^0.11.5",
     "uglify-es": "^3.3.9",
     "uglifyjs-webpack-plugin": "^1.2.4",
     "url-loader": "^1.0.1",
-    "webpack": "^3.11.0"
+    "webpack": "^4.37.0",
+    "webpack-cli": "^3.3.6"
   }
 }

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const CssoWebpackPlugin = require('csso-webpack-plugin').default;
 
 module.exports = {
@@ -17,10 +17,9 @@ module.exports = {
 		rules: [
 			{
 				test: /\.css$/,
-				use: ExtractTextPlugin.extract({
-					fallback: 'style-loader',
-					use: 'css-loader',
-				}),
+				use: [
+				   { loader: MiniCssExtractPlugin.loader }, 'css-loader',
+				 ],
 			},
 			{
 				test: /\.(png|jpg|gif)$/,
@@ -53,7 +52,11 @@ module.exports = {
 			'process.env.NODE_ENV': JSON.stringify('debug'),
 		}),
 		new webpack.optimize.ModuleConcatenationPlugin(),
-		new ExtractTextPlugin('/static/styles/[contenthash].css'),
+		new MiniCssExtractPlugin({
+			filename: '/static/styles/[contenthash].css',
+			chunkFilename: '[id].css',
+			ignoreOrder: false,
+		}),
 		new CssoWebpackPlugin({
 			restructure: false,
 		}),

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -2,44 +2,8 @@ const path = require('path');
 const webpack = require('webpack');
 const MinifyPlugin = require('babel-minify-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const CssoWebpackPlugin = require('csso-webpack-plugin').default;
-
-const uglifySettings = {
-	mangle: {
-		toplevel: true,
-		keep_fnames: false,
-	},
-	compress: {
-		sequences: true,
-		properties: true,
-		dead_code: true,
-		drop_debugger: true,
-		unsafe: true,
-		unsafe_math: true,
-		unsafe_proto: true,
-		conditionals: true,
-		comparisons: true,
-		evaluate: true,
-		booleans: false,
-		loops: true,
-		unused: true,
-		toplevel: true,
-		hoist_funs: true,
-		hoist_vars: true,
-		if_return: true,
-		join_vars: true,
-		cascade: true,
-		collapse_vars: true,
-		reduce_vars: true,
-		warnings: false,
-		pure_getters: true,
-		drop_console: true,
-		keep_fargs: false,
-		keep_fnames: false,
-		passes: 3,
-	},
-};
 
 module.exports = {
 	entry: {
@@ -50,14 +14,16 @@ module.exports = {
 		filename: '[name].[hash].js',
 		sourceMapFilename: '[name].[hash].map',
 	},
+	optimization: {
+		minimize: true
+	},
 	module: {
 		rules: [
 			{
 				test: /\.css$/,
-				use: ExtractTextPlugin.extract({
-					fallback: 'style-loader',
-					use: 'css-loader',
-				}),
+				use: [
+				   { loader: MiniCssExtractPlugin.loader }, 'css-loader',
+				 ],
 			},
 			{
 				test: /\.(png|jpg|gif)$/,
@@ -98,8 +64,11 @@ module.exports = {
 			removeDebugger: true,
 		}),
 		new webpack.optimize.ModuleConcatenationPlugin(),
-		new webpack.optimize.UglifyJsPlugin(uglifySettings),
-		new ExtractTextPlugin('/static/styles/[contenthash].css'),
+		new MiniCssExtractPlugin({
+			filename: '/static/styles/[contenthash].css',
+			chunkFilename: '[id].css',
+			ignoreOrder: false,
+		}),
 		new CssoWebpackPlugin({
 			restructure: true,
 			forceMediaMerge: true,


### PR DESCRIPTION
This commit updates deprecated webpack plugins, updates old npm packages and fixes #163 

- Updated ```css-loader``` to 3.1.0 for security reasons (as instructed by ```npm audti```). 
- Replaced ```extract-text-webpack-plugin``` (deprecated) with ```mini-css-extract-plugin```.
- I added the ```--mode``` option to webpack command to clearly distinguish development and production modes.
- Removed ```webpack.optimize.UglifyJsPlugin``` (deprecated) along with the ```uglifySettings``` from webpack.config.prod.js and replaced it with webpack.optimization.minimze.